### PR TITLE
Use from python as from cli

### DIFF
--- a/spectracl.py
+++ b/spectracl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import spectracl.__main__
+import spectracl.main
 
 
 if __name__ == '__main__':
-    spectracl.__main__.entry()
+    spectracl.main.entry()

--- a/spectracl/__main__.py
+++ b/spectracl/__main__.py
@@ -1,0 +1,4 @@
+import main
+
+if __name__ == '__main__':
+    main.entry()

--- a/spectracl/main.py
+++ b/spectracl/main.py
@@ -24,22 +24,22 @@ def entry():
         model = pickle.load(fh)
     with args.features_fp.open('r') as fh:
         features = [int(line.rstrip()) for line in fh]
-    # Discover fid files
-    fid_fps = list(args.spectra_dir.rglob('fid'))
-    if len(fid_fps) == 0:
-        print(f'error: did not find any fid files in {args.spectra_dir}', file=sys.stderr)
-        sys.exit(1)
 
-    for result in compute(features, fid_fps, model, sample_data):
+    for result in compute(features=features, data_dir=args.spectra_dir, model=model, sample_data=sample_data):
         print(*result, sep='\t')
 
 
 def compute(
-        features: List[int],
-        fid_fps: List[pathlib.Path],
-        model,
+        *,
+        data_dir: pathlib.Path,
         sample_data: dict,
+        model,
+        features: List[int],
 ) -> List:
+    # Discover fid files
+    fid_fps = list(data_dir.rglob('fid'))
+    assert len(fid_fps), f'error: did not find any fid files in {args.spectra_dir}'
+
     # Read in spectrum data and sort according to sample sheet, if provided
     spectra_grouped = dict()
     sp_identifiers = ['uid', 'sample_name', 'full_name', 'semi_unique_name']

--- a/spectracl/main.py
+++ b/spectracl/main.py
@@ -1,7 +1,7 @@
 import pathlib
 import pickle
 import sys
-
+from typing import List
 
 import pandas as pd
 import numpy as np
@@ -31,6 +31,15 @@ def entry():
         print(f'error: did not find any fid files in {args.spectra_dir}', file=sys.stderr)
         sys.exit(1)
 
+    compute(features, fid_fps, model, sample_data)
+
+
+def compute(
+        features: List[int],
+        fid_fps:  List[pathlib.Path],
+        model,
+        sample_data: dict,
+    ):
     # Read in spectrum data and sort according to sample sheet, if provided
     spectra_grouped = dict()
     sp_identifiers = ['uid', 'sample_name', 'full_name', 'semi_unique_name']

--- a/spectracl/main.py
+++ b/spectracl/main.py
@@ -80,7 +80,3 @@ def read_sample_sheet(fp):
             entry = {k: v for k, v in zip(header_tokens, line_tokens)}
             data[entry['spectrum_id']] = entry['sample_id']
     return data
-
-
-if __name__ == '__main__':
-    entry()

--- a/spectracl/main.py
+++ b/spectracl/main.py
@@ -6,7 +6,6 @@ from typing import List
 import pandas as pd
 import numpy as np
 
-
 from . import arguments
 from . import spectra
 
@@ -31,15 +30,16 @@ def entry():
         print(f'error: did not find any fid files in {args.spectra_dir}', file=sys.stderr)
         sys.exit(1)
 
-    compute(features, fid_fps, model, sample_data)
+    for result in compute(features, fid_fps, model, sample_data):
+        print(*result, sep='\t')
 
 
 def compute(
         features: List[int],
-        fid_fps:  List[pathlib.Path],
+        fid_fps: List[pathlib.Path],
         model,
         sample_data: dict,
-    ):
+) -> List:
     # Read in spectrum data and sort according to sample sheet, if provided
     spectra_grouped = dict()
     sp_identifiers = ['uid', 'sample_name', 'full_name', 'semi_unique_name']
@@ -75,7 +75,7 @@ def compute(
         species_index = np.argmax(probs)
         species_prob = round(probs[species_index] * 100, 2)
         species = model.classes_[species_index]
-        print(sample_name, species, species_prob, sep='\t')
+        yield sample_name, species, species_prob
 
 
 def read_sample_sheet(fp):

--- a/spectracl/main.py
+++ b/spectracl/main.py
@@ -38,7 +38,7 @@ def compute(
 ) -> List:
     # Discover fid files
     fid_fps = list(data_dir.rglob('fid'))
-    assert len(fid_fps), f'error: did not find any fid files in {args.spectra_dir}'
+    assert len(fid_fps), f'error: did not find any fid files in {data_dir}'
 
     # Read in spectrum data and sort according to sample sheet, if provided
     spectra_grouped = dict()

--- a/spectracl/spectra.py
+++ b/spectracl/spectra.py
@@ -85,7 +85,8 @@ def read_acqu_data(acqu_fp):
                 vtype = acqu_fields[var]['vtype']
                 assert name not in acqu_data
                 acqu_data[name] = vtype(val)
-    assert all(d['name'] in acqu_data for d in acqu_fields.values())
+    for d in acqu_fields.values():
+        assert d['name'] in acqu_data, f"Missing {d['name']} in {acqu_fp}" 
     # Apply further processing to spectra_uid and byte_order
     acqu_data['spectra_uid'] = acqu_data['spectra_uid'].strip('<>')
     acqu_data['byte_order'] = 'little' if acqu_data['byte_order'] == 0 else 'big'


### PR DESCRIPTION
Hi,

This PR split the entry() method to allows ktyper calling directly the python code (cf https://github.com/scwatts/ktyper/issues/15).

Event if the `File changed` tab doesn't show it, I did a `git mv` to preserve git history (cf https://github.com/scwatts/spectracl/blame/use-from-python-as-from-cli/spectracl/main.py)

